### PR TITLE
fix(ci): ensure portable EXE is attached in Windows release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -108,10 +108,21 @@ jobs:
         
         # --- Portable standalone EXE ---
         $appDir = "frontend\src-tauri\target\x86_64-pc-windows-msvc\release"
-        $appExe = Get-ChildItem $appDir -Filter "Web Whisper.exe" -ErrorAction SilentlyContinue | Select-Object -First 1
-        if ($appExe) {
-          Copy-Item $appExe.FullName "releases\web-whisper-portable.exe" -Force
-          Write-Host "Packaged portable EXE: $($appExe.Name)"
+        $portable = $null
+        # Try common Tauri binary names
+        $portable = Get-ChildItem $appDir -Filter "Web Whisper.exe" -ErrorAction SilentlyContinue | Select-Object -First 1
+        if (-not $portable) {
+          $portable = Get-ChildItem $appDir -Filter "web-whisper.exe" -ErrorAction SilentlyContinue | Select-Object -First 1
+        }
+        if (-not $portable) {
+          # Fallback: any exe that matches web whisper naming (case-insensitive)
+          $portable = Get-ChildItem $appDir -Filter *.exe -ErrorAction SilentlyContinue |
+            Where-Object { $_.Name -match '^(?i)web([ -])?whisper(.*)\.exe$' } |
+            Select-Object -First 1
+        }
+        if ($portable) {
+          Copy-Item $portable.FullName "releases\web-whisper-portable.exe" -Force
+          Write-Host "Packaged portable EXE: $($portable.Name)"
         } else {
           Write-Host "No portable EXE found in $appDir"
         }

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -152,10 +152,21 @@ jobs:
         
         # --- Portable standalone EXE ---
         $appDir = "frontend\src-tauri\target\x86_64-pc-windows-msvc\release"
-        $appExe = Get-ChildItem $appDir -Filter "Web Whisper.exe" -ErrorAction SilentlyContinue | Select-Object -First 1
-        if ($appExe) {
-          Copy-Item $appExe.FullName "releases\web-whisper-portable.exe" -Force
-          Write-Host "Packaged portable EXE: $($appExe.Name)"
+        $portable = $null
+        # Try common Tauri binary names
+        $portable = Get-ChildItem $appDir -Filter "Web Whisper.exe" -ErrorAction SilentlyContinue | Select-Object -First 1
+        if (-not $portable) {
+          $portable = Get-ChildItem $appDir -Filter "web-whisper.exe" -ErrorAction SilentlyContinue | Select-Object -First 1
+        }
+        if (-not $portable) {
+          # Fallback: any exe that matches web whisper naming (case-insensitive)
+          $portable = Get-ChildItem $appDir -Filter *.exe -ErrorAction SilentlyContinue |
+            Where-Object { $_.Name -match '^(?i)web([ -])?whisper(.*)\.exe$' } |
+            Select-Object -First 1
+        }
+        if ($portable) {
+          Copy-Item $portable.FullName "releases\web-whisper-portable.exe" -Force
+          Write-Host "Packaged portable EXE: $($portable.Name)"
         } else {
           Write-Host "No portable EXE found in $appDir"
         }


### PR DESCRIPTION
This PR fixes missing 'web-whisper-portable.exe' in Windows releases.\n\nChanges:\n- Robust detection of Tauri app EXE: tries 'Web Whisper.exe' and 'web-whisper.exe'\n- Fallback regex to match case-insensitive 'web whisper*.exe'\n\nWhy:\n- Prior releases occasionally missed the portable asset when the app binary name differed from 'Web Whisper.exe'.\n\nSteps to verify (after merge):\n1. Run: Windows Release workflow via 'workflow_dispatch' with a fresh tag (e.g., v0.1.1)\n2. Confirm release assets include: web-whisper-portable.exe, web-whisper-windows-x64.msi, web-whisper-windows-x64-installer.exe, whisper-gui-core.exe\n\nCI: No functional code changes beyond workflows.