### PR TITLE
feat(ci): add Windows Release Lite (manual)

### DIFF
--- a/.github/workflows/release-lite.yml
+++ b/.github/workflows/release-lite.yml
@@ -1,0 +1,197 @@
+name: Windows Release Lite
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Release version (e.g., v0.1.8)'
+        required: true
+        type: string
+
+permissions:
+  contents: write
+
+env:
+  PYTHON_VERSION: "3.11"
+  RUST_BACKTRACE: 1
+
+jobs:
+  build-windows-lite:
+    runs-on: windows-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Enable Corepack
+        run: corepack enable
+
+      - name: Setup pnpm via packageManager field
+        working-directory: frontend
+        run: corepack use pnpm
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: x86_64-pc-windows-msvc
+
+      - name: Cache dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            frontend/src-tauri/target
+            ~/.pnpm-store
+            ~\AppData\Local\pip\Cache
+          key: windows-release-lite-${{ hashFiles('frontend/src-tauri/Cargo.lock', 'frontend/pnpm-lock.yaml', 'backend/requirements.txt') }}
+          restore-keys: |
+            windows-release-lite-
+
+      - name: Install Python dependencies
+        working-directory: backend
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install pyinstaller
+
+      - name: Build backend executable
+        working-directory: backend
+        run: |
+          pyinstaller main.py --onefile --name whisper-gui-core.exe `
+            --collect-all faster_whisper `
+            --collect-all ctranslate2 `
+            --collect-all gradio `
+            --collect-all gradio_client `
+            --collect-data safehttpx `
+            --collect-data gradio_client `
+            --collect-data groovy `
+            --add-data "configs;configs" `
+            --add-data "scripts;scripts" `
+            --hidden-import=mlx_whisper `
+            --hidden-import=faster_whisper `
+            --hidden-import=ctranslate2 `
+            --hidden-import=gradio `
+            --hidden-import=safehttpx `
+            --console
+
+      - name: Install frontend dependencies
+        working-directory: frontend
+        run: pnpm install --frozen-lockfile
+
+      - name: Generate Tauri icons
+        working-directory: frontend
+        run: pnpm tauri icon src-tauri/icons/icon.png
+
+      - name: Build Tauri application
+        working-directory: frontend
+        run: pnpm tauri build --target x86_64-pc-windows-msvc
+
+      - name: Package Windows build
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = "Stop"
+          New-Item -ItemType Directory -Path releases -Force | Out-Null
+
+          # Portable exe
+          $appDir = "frontend\src-tauri\target\x86_64-pc-windows-msvc\release"
+          $portable = Get-ChildItem $appDir -Filter "Web Whisper.exe" -ErrorAction SilentlyContinue | Select-Object -First 1
+          if (-not $portable) { $portable = Get-ChildItem $appDir -Filter "web-whisper.exe" -ErrorAction SilentlyContinue | Select-Object -First 1 }
+          if (-not $portable) { $portable = Get-ChildItem $appDir -Filter *.exe -ErrorAction SilentlyContinue | Where-Object { $_.Name -match '^(?i)web([ -])?whisper(.*)\.exe$' } | Select-Object -First 1 }
+          if ($portable) { Copy-Item $portable.FullName "releases\web-whisper-portable.exe" -Force } else { throw "Portable EXE not found" }
+
+          # MSI/NSIS installers
+          $msiDir = "frontend\src-tauri\target\x86_64-pc-windows-msvc\release\bundle\msi"
+          $msi = Get-ChildItem $msiDir -Filter *.msi -ErrorAction SilentlyContinue | Select-Object -First 1
+          if ($msi) { Copy-Item $msi.FullName "releases\web-whisper-windows-x64.msi" -Force }
+          $nsisDir = "frontend\src-tauri\target\x86_64-pc-windows-msvc\release\bundle\nsis"
+          $nsis = Get-ChildItem $nsisDir -Filter *.exe -ErrorAction SilentlyContinue | Select-Object -First 1
+          if ($nsis) { Copy-Item $nsis.FullName "releases\web-whisper-windows-x64-installer.exe" -Force }
+
+          # Backend EXE
+          $backendExe = "backend\dist\whisper-gui-core.exe"
+          if (Test-Path $backendExe) { Copy-Item $backendExe "releases\whisper-gui-core.exe" -Force } else { throw "Backend exe not found: $backendExe" }
+
+      - name: Ensure 7-Zip available
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = "Stop"
+          if (-not (Get-Command 7z -ErrorAction SilentlyContinue)) {
+            choco install 7zip -y --no-progress
+          }
+
+      - name: Build Onefile Lite (SFX)
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = "Stop"
+          New-Item -ItemType Directory -Path onefile -Force | Out-Null
+          Copy-Item releases\web-whisper-portable.exe onefile\ -Force
+          Copy-Item releases\whisper-gui-core.exe onefile\ -Force
+
+          $launcherPs1 = @'
+Param()
+$ErrorActionPreference = "Stop"
+try { [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12 } catch {}
+$ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Definition
+$BinDir = Join-Path $env:LOCALAPPDATA 'WebWhisper\bin'
+New-Item -ItemType Directory -Path $BinDir -Force | Out-Null
+$FfmpegPath = Join-Path $BinDir 'ffmpeg.exe'
+if (-not (Test-Path $FfmpegPath)) {
+  $ffUrl = 'https://www.gyan.dev/ffmpeg/builds/ffmpeg-release-essentials.zip'
+  $tmpZip = Join-Path $env:TEMP ('ffmpeg_' + [Guid]::NewGuid().ToString() + '.zip')
+  Invoke-WebRequest -Uri $ffUrl -OutFile $tmpZip -UseBasicParsing
+  $tmpDir = Join-Path $env:TEMP ('ffmpeg_' + [Guid]::NewGuid().ToString())
+  New-Item -ItemType Directory -Path $tmpDir -Force | Out-Null
+  Expand-Archive -Path $tmpZip -DestinationPath $tmpDir -Force
+  $ffExe = Get-ChildItem -Path $tmpDir -Recurse -Filter ffmpeg.exe | Select-Object -First 1
+  if (-not $ffExe) { throw 'ffmpeg.exe not found in downloaded archive' }
+  Copy-Item $ffExe.FullName $FfmpegPath -Force
+}
+$Bootstrapper = Join-Path $ScriptDir 'MicrosoftEdgeWebView2RuntimeInstallerX64.exe'
+if (-not (Test-Path $Bootstrapper)) {
+  try { Invoke-WebRequest -Uri 'https://go.microsoft.com/fwlink/p/?LinkId=2124703' -OutFile $Bootstrapper -UseBasicParsing } catch {}
+}
+if (Test-Path $Bootstrapper) { Start-Process -FilePath $Bootstrapper -ArgumentList '/silent','/install' -Wait -NoNewWindow }
+$env:PATH = "$BinDir;" + $env:PATH
+Start-Process -FilePath (Join-Path $ScriptDir 'web-whisper-portable.exe') -WorkingDirectory $ScriptDir
+'@
+          Set-Content -Path onefile\run.ps1 -Value $launcherPs1 -Encoding UTF8
+
+          $sfxCfg = @'
+;!@Install@!UTF-8!
+Title="Web Whisper (Onefile Lite)"
+RunProgram="powershell -NoProfile -ExecutionPolicy Bypass -File run.ps1"
+;!@InstallEnd@!
+'@
+          Set-Content -Path config.txt -Value $sfxCfg -Encoding UTF8
+          & 7z a -t7z -mx=9 onefile.7z .\onefile\* | Out-Null
+          $sfx = "$Env:ProgramFiles\7-Zip\7zsd.sfx"
+          if (-not (Test-Path $sfx)) { $sfx = "$Env:ProgramFiles(x86)\7-Zip\7zsd.sfx" }
+          if (-not (Test-Path $sfx)) { throw "7z SFX module not found" }
+          New-Item -ItemType Directory -Path releases -Force | Out-Null
+          cmd /c copy /b "$sfx"+"config.txt"+"onefile.7z" "releases\web-whisper-onefile-lite.exe" > nul
+
+      - name: Create GitHub Release (Lite)
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: ${{ inputs.version }}
+          name: Web Whisper ${{ inputs.version }} (Lite)
+          files: releases/*
+          generate_release_notes: true
+          body: |
+            ## Web Whisper ${{ inputs.version }} (Onefile Lite)
+
+            - Onefile Lite: `web-whisper-onefile-lite.exe` (downloads WebView2 + ffmpeg on first run)
+            - Also includes: portable, MSI, NSIS, backend executables
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+


### PR DESCRIPTION
Add a manual-only Windows Release Lite workflow to avoid tag-trigger flakiness.\n- Outputs web-whisper-onefile-lite.exe\n- Includes portable/MSI/NSIS/backend artifacts\n- Release is created from provided 'version' input